### PR TITLE
Fixed chessboard image link from 'Chessboard.png' to 'ChessBoard.png'

### DIFF
--- a/KTANE/Centurion.html
+++ b/KTANE/Centurion.html
@@ -1701,7 +1701,7 @@
     <div class="page-content">
         <h4>Chess Board Reference</h4>
         <p style="margin: 0;">Use the following graphic as a reference for the chess board layout</p>
-        <img src="img/modules/chess/Chessboard.png"  class="chess-chessboard">
+        <img src="img/modules/chess/ChessBoard.png"  class="chess-chessboard">
         <div class="chess-vertical">
             <span>6</span>
             <span>5</span>


### PR DESCRIPTION
The chessboard wouldnt show due to a typo in the IMG ref, meant to be ChessBoard.png, showed Chessboard.png (which didnt exist)